### PR TITLE
fixes typo preventing the heroku console from running

### DIFF
--- a/lib/SlackAutoInviter.js
+++ b/lib/SlackAutoInviter.js
@@ -2,7 +2,7 @@ var Promise = require('bluebird'),
 	PromiseObject = require('promise-object')(Promise),
 	request = require('request'),
 	_ = require('lodash'),
-	Cubby = require('Cubby');
+	Cubby = require('cubby');
 
 Promise.promisifyAll(request);
 


### PR DESCRIPTION
This was indeed the solution for issue #3. Heroku wont let if fly.
